### PR TITLE
err variable misnamed -> error

### DIFF
--- a/lib/abstract/install.js
+++ b/lib/abstract/install.js
@@ -107,7 +107,7 @@ module.exports = function (version, done) {
     if(!exists) fs.mkdirSync(dirname.typescript);
     child_process.exec(command, function (error, stdout) {
       if (error) {
-        console.log(err);
+        console.log(error);
       } else {
         callback(null);
       }


### PR DESCRIPTION
Trying to get this to work on Windows, triggered this typo since I don't have an equivalent cp utility in my environment yet.