### PR TITLE
Verify if callback 'done' is defined, always print stdout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,5 @@ script:
 language: node_js
 
 node_js:
-  - iojs
-  - "0.12"
-  - "0.10"
+  - "8.9.4"
+

--- a/lib/abstract/install.js
+++ b/lib/abstract/install.js
@@ -12,7 +12,7 @@ module.exports = function (version, done) {
     var exists = fs.existsSync(dirname.typescript + 'v' + version);
     if (exists) {
       console.log('v' + version +' is already installed.\n');
-      done();
+      if (typeof done === 'function') done();
     } else {
       console.log('Searching...\n');
       callback(null);

--- a/lib/abstract/install_latest.js
+++ b/lib/abstract/install_latest.js
@@ -31,7 +31,7 @@ module.exports = function (done) {
     var exists = fs.existsSync(dirname.typescript + 'v' + version);
     if (exists) {
       console.log('\nv' + version + ' is already installed.');
-      done();
+      if (typeof done === 'function') done();
     } else {
       console.log('Now installing v' + version);
       callback(null, tarball);

--- a/lib/abstract/tsc.js
+++ b/lib/abstract/tsc.js
@@ -2,14 +2,13 @@ module.exports = function (option, done) {
   'use strict';
   var async         = require('async');
   var fs            = require('fs');
-  var util          = require('util');
   var child_process = require('child_process');
   var dirname       = require('../config/dirname');
 
   async.waterfall([function (callback) {
     var exists        = fs.existsSync(dirname.current);
     if (!exists) {
-      util.print('tvm use <version>');
+      console.log(console.log('tvm use <version>'));
       return;
     } else {
       callback(null);
@@ -20,10 +19,10 @@ module.exports = function (option, done) {
 
     child_process.exec(command, function (error, stdout) {
       if (error) {
-        util.print(error);
-      } else {
-        util.print(stdout);
+        console.log(error);
       }
+      console.log(stdout);
+
       if (typeof done === 'function') done();
     });
   }]);


### PR DESCRIPTION
Two fixes

- In install and install_latest, if the specified version already existed, it would call the callback without verifying if it was passed.

- When launching `tsc` to compile the file, it would only print out the error object if it existed. Issue with this is we don't see compiler errors. Fix this by always printing stdout. Also, use `console.log` instead of `util.print`.